### PR TITLE
Add therubyracer; a requirement for building the dummy app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-1-stable'
+gem 'therubyracer', platforms: :ruby
 gem 'sisow', '~> 1.5'
 
 gemspec


### PR DESCRIPTION
 When using a clean environment, or some method that cotnains the gem environments
(such as rvm or rbenv) you don't have this gem lying around.·
In that case building the dummy app fails.

By including a js executer it passes.
