### PR TITLE
Remove unused boilerplate assets.

### DIFF
--- a/app/assets/javascripts/admin/spree_billing_sisow.js
+++ b/app/assets/javascripts/admin/spree_billing_sisow.js
@@ -1,1 +1,0 @@
-//= require admin/spree_backend

--- a/app/assets/javascripts/store/spree_billing_sisow.js
+++ b/app/assets/javascripts/store/spree_billing_sisow.js
@@ -1,1 +1,0 @@
-//= require store/spree_frontend

--- a/app/assets/stylesheets/admin/spree_billing_sisow.css
+++ b/app/assets/stylesheets/admin/spree_billing_sisow.css
@@ -1,3 +1,0 @@
-/*
- *= require admin/spree_backend
-*/

--- a/app/assets/stylesheets/store/spree_billing_sisow.css
+++ b/app/assets/stylesheets/store/spree_billing_sisow.css
@@ -1,3 +1,0 @@
-/*
- *= require store/spree_frontend
-*/

--- a/lib/generators/spree_billing_sisow/install/install_generator.rb
+++ b/lib/generators/spree_billing_sisow/install/install_generator.rb
@@ -5,13 +5,9 @@ module SpreeBillingSisow
       class_option :auto_run_migrations, :type => :boolean, :default => false
 
       def add_javascripts
-        append_file 'app/assets/javascripts/store/all.js', "//= require store/spree_billing_sisow\n"
-        append_file 'app/assets/javascripts/admin/all.js', "//= require admin/spree_billing_sisow\n"
       end
 
       def add_stylesheets
-        inject_into_file 'app/assets/stylesheets/store/all.css', " *= require store/spree_billing_sisow\n", :before => /\*\//, :verbose => true
-        inject_into_file 'app/assets/stylesheets/admin/all.css', " *= require admin/spree_billing_sisow\n", :before => /\*\//, :verbose => true
       end
 
       def add_migrations


### PR DESCRIPTION
As discussedin #5 : removing the JS and CSS which currently only includes spree assets.

Inlcuding that causes two problems: 
1. Sites who deliberately did not include a certain asset from spree_frontend or spree_backend will suddently break.
2. It causes overhead on installing and adds quite some surface of files and code that need to be maintained in upgrades, but are never really used.

EDIT: note that this PR will probably conflict with PR #6 but once either one is merged (or declined) I'll update the other.
