### PR TITLE
Spec the behaviour of the rescue in SisowStatusController#update

### DIFF
--- a/spec/controllers/spree/sisow_status_controller_spec.rb
+++ b/spec/controllers/spree/sisow_status_controller_spec.rb
@@ -10,15 +10,17 @@ describe Spree::SisowStatusController do
     double(Spree::BillingIntegration::SisowBilling)
   }
 
-  it "should update the transaction status" do
-    params = {
+  let(:params) do
+    {
         "order_id" => "O12345678",
         "trxid" => "12345",
         "ec" => "54321",
         "status" => "Pending",
         "sha1" => "1234567890"
     }
+  end
 
+  it "should update the transaction status" do
     test_params = params.clone
     test_params.delete(:use_route)
     test_params.merge!({"controller" => "spree/sisow_status", "action"=>"update"})
@@ -28,5 +30,22 @@ describe Spree::SisowStatusController do
     Spree::BillingIntegration::SisowBilling.stub(:new).and_return(billing_integration)
 
     spree_post :update, params
+  end
+
+  describe "confirming a none-existing order" do
+    before do
+      Spree::Order.stub(:find_by_number!).with("O12345678").and_raise(ActiveRecord::RecordNotFound)
+    end
+
+    it "should log an error" do
+      # Somehow in our spree, Logger is not defined on Rails but on ActionController.
+      ActionController::Base.logger.should_receive(:error).with(/ERROR:.*\(O12345678\) not found/)
+      spree_post :update, params
+    end
+
+    it "should return HTTP status code 500" do
+      spree_post :update, params
+      response.status.should eq 500
+    end
   end
 end


### PR DESCRIPTION
I was debugging an integration issue through tests and thought a few of the tests might be usefull to add upstream.

These tests spec the interesting part of the behaviour of the begin-rescue in SisowStatusController#update
